### PR TITLE
fix: Implement static site generation for playbook deployment

### DIFF
--- a/.github/scripts/build_site.py
+++ b/.github/scripts/build_site.py
@@ -1,0 +1,95 @@
+
+import os
+import glob
+import markdown
+from bs4 import BeautifulSoup
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), '..')
+SECTIONS_DIR = os.path.join(REPO_ROOT, 'sections')
+TEMPLATES_DIR = REPO_ROOT
+
+INDEX_TEMPLATE_PATH = os.path.join(TEMPLATES_DIR, 'index_template.html')
+OUTPUT_INDEX_PATH = os.path.join(REPO_ROOT, 'index.html')
+
+def build_navigation(section_files):
+    nav_html = []
+    for filepath, title in section_files:
+        # Generate a clean ID for the anchor link
+        # Example: sections/01-definition/README.md -> chapter-01-definition
+        section_id = "chapter-" + os.path.basename(os.path.dirname(filepath)).replace('-', '_')
+        nav_html.append(f'<a href="#{section_id}">{title}</a>')
+    return '\n'.join(nav_html)
+
+def build_content(section_files):
+
+    full_content_html = []
+    for filepath, title in section_files:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            md_content = f.read()
+        html_content = markdown.markdown(md_content) # Convert Markdown to HTML
+
+        # Generate a clean ID for the anchor link
+        section_id = "chapter-" + os.path.basename(os.path.dirname(filepath)).replace('-', '_')
+
+        # Wrap content in a section with the appropriate ID and title
+        full_content_html.append(f'<section id="{section_id}" class="chapter">\n')
+        full_content_html.append(f'<h2 id="{section_id}-title">{title}</h2>\n')
+        full_content_html.append(html_content)
+        full_content_html.append(f'\n</section>\n')
+
+    return '\n'.join(full_content_html)
+
+def get_section_info(directory):
+    # Assumes each chapter is in its own directory (e.g., sections/01-definition)
+    # And the main content is README.md inside it, or 01-something.md
+    
+    section_data = []
+    chapter_dirs = sorted([d for d in os.listdir(directory) if os.path.isdir(os.path.join(directory, d))])
+
+    for chapter_dir_name in chapter_dirs:
+        chapter_path = os.path.join(directory, chapter_dir_name)
+        main_md_file = os.path.join(chapter_path, 'README.md')
+        
+        if not os.path.exists(main_md_file): # If no README.md, try to find a .md file named after the chapter (e.g. 01-definition.md)
+            md_files = glob.glob(os.path.join(chapter_path, '*.md'))
+            if md_files:
+                main_md_file = sorted(md_files)[0] # Take the first one if multiple
+            else:
+                continue # Skip if no markdown file found
+                
+        # Read title from the first H1 in the Markdown file
+        with open(main_md_file, 'r', encoding='utf-8') as f:
+            first_line = f.readline().strip()
+            if first_line.startswith('# '):
+                title = first_line[2:].strip()
+            else:
+                title = chapter_dir_name.replace('_', ' ').title() # Fallback to directory name
+        
+        section_data.append((main_md_file, title))
+    return section_data
+
+if __name__ == "__main__":
+    print("Starting site build...")
+    
+    # Get section files details
+    section_files_info = get_section_info(SECTIONS_DIR)
+
+    # Build navigation
+    navigation_html = build_navigation(section_files_info)
+    
+    # Build main content
+    main_content_html = build_content(section_files_info)
+
+    # Read template
+    with open(INDEX_TEMPLATE_PATH, 'r', encoding='utf-8') as f:
+        template_content = f.read()
+
+    # Inject content and navigation
+    final_html = template_content.replace('<!-- NAVIGATION_PLACEHOLDER -->', navigation_html)
+    final_html = final_html.replace('<!-- CONTENT_PLACEOLDER -->', main_content_html)
+
+    # Write final index.html
+    with open(OUTPUT_INDEX_PATH, 'w', encoding='utf-8') as f:
+        f.write(final_html)
+
+    print(f"Successfully built {OUTPUT_INDEX_PATH}")

--- a/.github/workflows/deploy-playbook.yml
+++ b/.github/workflows/deploy-playbook.yml
@@ -1,0 +1,37 @@
+name: Deploy Playbook
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies (for markdown conversion)
+        run: pip install markdown beautifulsoup4
+
+      - name: Build site with Python script
+        run: python .github/scripts/build_site.py
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./ # Publish the root directory where index.html is generated
+          force_orphan: true # Overwrite history of gh-pages branch

--- a/index_template.html
+++ b/index_template.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The OpenClaw Field Playbook</title>
+  <link rel="stylesheet" href="/assets/style.css">
+</head>
+<body>
+
+<nav id="topnav">
+  <div class="nav-brand"><a href="/">The OpenClaw Field Playbook</a></div>
+  <button class="menu-toggle" onclick="toggleMenu()">☰</button>
+  <div class="nav-actions">
+    <button class="btn-pdf" onclick="generateLivePDF()">Download PDF</button>
+    <a href="https://github.com/alexwill87/openclaw-field-playbook" class="btn-github" target="_blank">View on GitHub</a>
+  </div>
+</nav>
+
+<div class="layout-wrapper">
+  <aside class="sidebar">
+    <nav id="side-nav">
+      <!-- NAVIGATION_PLACEHOLDER -->
+    </nav>
+  </aside>
+
+  <main id="content">
+    <!-- CONTENT_PLACEHOLDER -->
+  </main>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
+<script src="/assets/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This PR fixes the playbook website deployment by implementing a Python script to build the HTML from Markdown sections, and a new GitHub Actions workflow to run it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub Pages deployment pipeline and introduces a new static-site build step; a placeholder mismatch (`CONTENT_PLACEOLDER` vs `CONTENT_PLACEHOLDER`) could result in missing rendered content in the deployed site.
> 
> **Overview**
> Adds a Python-based static site build that concatenates `sections/*` Markdown into a single `index.html`, generating sidebar navigation anchors and injecting both nav/content into `index_template.html`.
> 
> Introduces a new `Deploy Playbook` GitHub Actions workflow that installs Python deps, runs the build script on pushes to `main`, and publishes the repository root to GitHub Pages via `peaceiris/actions-gh-pages`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74f81dc88d84b8be1002bad3e7df4df46be700a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->