### PR TITLE
fix: Ensure CNAME is copied for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-playbook.yml
+++ b/.github/workflows/deploy-playbook.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Build site with Python script
         run: python .github/scripts/build_site.py
 
+      - name: Copy CNAME file
+        run: cp CNAME ./ # Ensure CNAME is in the publish_dir
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
This PR fixes potential CNAME issues during GitHub Pages deployment by explicitly copying the CNAME file before publishing.